### PR TITLE
fix: add import error

### DIFF
--- a/app/components/dialogs/DialogLockFunds.tsx
+++ b/app/components/dialogs/DialogLockFunds.tsx
@@ -77,7 +77,7 @@ export default function DialogLockFunds({ pair, isOpen, onClose, onAfterSubmit }
         toaster.show({
           icon: "endorsed",
           intent: Intent.SUCCESS,
-          message: "Lock reqeust is submitted",
+          message: "Lock request is submitted",
         });
       onAfterSubmit();
     } catch (e) {

--- a/app/components/wallet/Wallet.client.tsx
+++ b/app/components/wallet/Wallet.client.tsx
@@ -28,7 +28,13 @@ export default function Wallet() {
 
   function handleSeedPhraseImportClick(seed_phrase, password) {
     try {
-      keyring.addUri(seed_phrase, password);
+      const currentPairs = keyring.getPairs();
+      const result = keyring.addUri(seed_phrase, password);
+      
+      if(currentPairs.some((keyringAddress) => keyringAddress.address === result.pair.address)) {
+        throw new Error(`Wallet already imported`);
+      }
+      
       dialogToggle("seed_phrase");
     } catch (e) {
       toaster &&


### PR DESCRIPTION
Throws an error toaster when importing a seed that already exists in the keyring rather than failing silently.