### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/codeball.yml
+++ b/.github/workflows/codeball.yml
@@ -10,7 +10,7 @@ jobs:
     name: Codeball
     steps:
       - name: Codeball
-        uses: sturdy-dev/codeball-action@v2
+        uses: sturdy-dev/codeball-action@v2.6.0
         with:
           # For all configuration options see https://github.com/sturdy-dev/codeball-action/blob/v2/action.yml
           approvePullRequests: "true"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.0
 
       - name: 👀 Read app name
         uses: SebRollen/toml-action@v1.0.2
@@ -30,11 +30,11 @@ jobs:
           field: "app"
 
       - name: 🐳 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.4.1
+        uses: docker/setup-buildx-action@v2.5.0
 
       # Setup cache
       - name: ⚡️ Cache Docker layers
-        uses: actions/cache@v3.2.4
+        uses: actions/cache@v3.3.1
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -49,7 +49,7 @@ jobs:
           password: ${{ secrets.FLY_API_TOKEN }}
 
       - name: 🐳 Docker build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4.0.0
         with:
           context: .
           push: true
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.0
 
       - name: 👀 Read app name
         uses: SebRollen/toml-action@v1.0.2
@@ -90,7 +90,7 @@ jobs:
           field: "app"
 
       - name: 🚀 Deploy Production
-        uses: superfly/flyctl-actions@1.1
+        uses: superfly/flyctl-actions@1.3
         with:
           args: "deploy --image registry.fly.io/${{ steps.app_name.outputs.value }}:${{ github.ref_name }}-${{ github.sha }}"
         env:

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v4.0.0](https://github.com/docker/build-push-action/releases/tag/v4.0.0)** on 2023-01-30T18:26:38Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.3.1](https://github.com/actions/cache/releases/tag/v3.3.1)** on 2023-03-13T05:05:19Z
* **[superfly/flyctl-actions](https://github.com/superfly/flyctl-actions)** published a new release **[1.3](https://github.com/superfly/flyctl-actions/releases/tag/1.3)** on 2022-02-04T22:50:52Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v2.5.0](https://github.com/docker/setup-buildx-action/releases/tag/v2.5.0)** on 2023-03-10T09:47:20Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.0](https://github.com/actions/checkout/releases/tag/v3.5.0)** on 2023-03-24T05:41:31Z
* **[sturdy-dev/codeball-action](https://github.com/sturdy-dev/codeball-action)** published a new release **[v2.6.0](https://github.com/sturdy-dev/codeball-action/releases/tag/v2.6.0)** on 2022-09-12T14:24:09Z
