### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
           field: "app"
 
       - name: 🐳 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
+        uses: docker/setup-buildx-action@v2.6.0
 
       # Setup cache
       - name: ⚡️ Cache Docker layers
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: 🔑 Fly Registry Auth
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v2.2.0
         with:
           registry: registry.fly.io
           username: x


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v2.2.0](https://github.com/docker/login-action/releases/tag/v2.2.0)** on 2023-06-07T13:07:43Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v2.6.0](https://github.com/docker/setup-buildx-action/releases/tag/v2.6.0)** on 2023-06-07T13:43:35Z
