### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
           field: "app"
 
       - name: 🐳 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.7.0
+        uses: docker/setup-buildx-action@v2.8.0
 
       # Setup cache
       - name: ⚡️ Cache Docker layers


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v2.8.0](https://github.com/docker/setup-buildx-action/releases/tag/v2.8.0)** on 2023-06-28T15:33:24Z
